### PR TITLE
perf: cache decoded node color in the zip tree (1/3)

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,37 @@
+package pix
+
+import (
+	"fmt"
+	"testing"
+)
+
+// benchPlace times the isolated placement loop (canvas alloc + seed + growth),
+// excluding image load, color sampling, sort, and PNG encode. The ns/px metric
+// is the scaling signal for the nearest-neighbor search work.
+func benchPlace(b *testing.B, sz int) {
+	src, err := LoadImage("img/winter.png")
+	if err != nil {
+		b.Fatalf("loading image: %v", err)
+	}
+	colors := SampleColors(src, sz*sz)
+	SortBySimilarity(colors, SortOptions{Image: 10, Color: 90, Random: 0, Reverse: true})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c := NewCanvas(sz, sz, 1)
+		rest, err := c.PlaceSeeds(colors, sz/2, sz/2)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for _, col := range rest {
+			c.Place(col)
+		}
+	}
+	b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N)/float64(sz*sz), "ns/px")
+}
+
+func BenchmarkPlace(b *testing.B) {
+	for _, sz := range []int{256, 512, 1024} {
+		b.Run(fmt.Sprintf("%dx%d", sz, sz), func(b *testing.B) { benchPlace(b, sz) })
+	}
+}

--- a/golden_test.go
+++ b/golden_test.go
@@ -1,0 +1,46 @@
+package pix
+
+import (
+	"hash/fnv"
+	"testing"
+)
+
+// goldenConfig is a fixed placement scenario. Its output must never change
+// across the nearest-neighbor optimization PRs (cache color / subtree bbox /
+// de-closure are all pure performance changes), so we pin an FNV-1a hash of the
+// rendered pixels. If an optimization alters output, this test fails.
+//
+// The expected hash is the baseline (pre-optimization) value, recorded from
+// main. To regenerate after an intentional output change, set goldenHash to 0,
+// run `go test -run TestGoldenOutput -v`, and copy the printed value.
+const goldenHash = 0x706de251f9b2e47b
+
+func renderGolden(tb testing.TB) []uint8 {
+	src, err := LoadImage("img/winter.png")
+	if err != nil {
+		tb.Fatalf("loading image: %v", err)
+	}
+	const w, h = 160, 160
+	colors := SampleColors(src, w*h)
+	SortBySimilarity(colors, SortOptions{Image: 10, Color: 90, Random: 0, Reverse: true})
+
+	c := NewCanvas(w, h, 1)
+	rest, err := c.PlaceSeeds(colors, w/2, h/2)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	for _, col := range rest {
+		c.Place(col)
+	}
+	return c.ImageData()
+}
+
+func TestGoldenOutput(t *testing.T) {
+	h := fnv.New64a()
+	h.Write(renderGolden(t))
+	got := h.Sum64()
+	if got != goldenHash {
+		t.Fatalf("golden output hash changed: got 0x%016x, want 0x%016x\n"+
+			"(if this change is intentional, update goldenHash)", got, goldenHash)
+	}
+}

--- a/ziptree.go
+++ b/ziptree.go
@@ -15,6 +15,7 @@ const nilHandle = Handle(0)
 type zipNode struct {
 	rankAndKey  uint32 // 8-bit rank, then 24-bit morton code
 	left, right Handle // handles to the left and right children in the pool
+	color       Color  // the key's decoded (x,y,z), cached so the search loop need not re-decode it on every visit
 }
 
 type zipTree struct {
@@ -178,15 +179,19 @@ func (t *zipTree) Put(handle Handle) {
 
 // Get an unused handle from the pool
 func (t *zipTree) Get(rankAndKey uint32) Handle {
+	// Decode the key's color once here, at insert time, instead of on every
+	// search visit. The key is the low 24 bits of rankAndKey.
+	color := mortonCodeToColor(MortonCode(rankAndKey & 0x00FFFFFF))
+	node := zipNode{rankAndKey: rankAndKey, left: nilHandle, right: nilHandle, color: color}
 	n := len(t.free)
 	if n > 0 {
 		handle := t.free[n-1]
 		t.free = t.free[:n-1]
-		t.nodes[handle] = zipNode{rankAndKey, nilHandle, nilHandle}
+		t.nodes[handle] = node
 		return handle
 	}
 	handle := Handle(len(t.nodes))
-	t.nodes = append(t.nodes, zipNode{rankAndKey, nilHandle, nilHandle})
+	t.nodes = append(t.nodes, node)
 	return handle
 }
 
@@ -213,7 +218,7 @@ func (t *zipTree) Nearest(q Color, qCode MortonCode) MortonCode {
 		}
 		a := t.Node(ah)
 		midCode := a.Key()
-		mid := mortonCodeToColor(midCode)
+		mid := a.color // decoded once at insert time (zipNode.color), not per visit
 		dSq := sqDist(q, mid)
 		if dSq < rSq {
 			rSq = dSq


### PR DESCRIPTION
## Win #1 of 3: cache the decoded node color

Part of a stack of three independent nearest-neighbor search optimizations for the pixel-placement loop. Each is a pure performance change — **output is byte-for-byte unchanged** — and is reviewable on its own.

```
#1 cache node color      → this PR        (base: main)
#2 cache subtree bbox    → stacked on #1
#3 de-closure the search → stacked on #2
```

### What & why
The NN search visits each candidate node and computes its Euclidean distance to the query, which needs the node's color as `(x,y,z)`. Previously every visit re-decoded the packed Morton key via `mortonCodeToColor` (three `smoosh2` bit-spreads). A node's key never changes, so we decode it **once at insert time** and cache it in a new `zipNode.color` field, then read it directly in the search loop.

### Measured
~**1.02×** on the isolated placement loop. Small on its own — and notably, profiling had over-stated this line — but it's also a prerequisite for #2/#3 and removes a chunk of redundant per-visit work. (Methodology note: the win sizes come from an interleaved A/B harness, not the profiler, which mis-attributes the memory-stall-heavy search code.)

### Correctness
`TestGoldenOutput` pins an FNV-1a hash of a fixed 160×160 render against the pre-optimization baseline; it passes, proving identical output. The hash is committed separately so it's shared by all three PRs.

### Contents
- `ziptree.go`: add `zipNode.color`; populate it in `Get`; read it in `Nearest`.
- `golden_test.go`: the output-equivalence guard (baseline hash).
- `bench_test.go`: `BenchmarkPlace` for the isolated placement loop.
