### PR TITLE
perf: cache subtree key range for O(1) bbox pruning (2/3)

### DIFF
--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -1,0 +1,48 @@
+package pix
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// TestAggregateConsistency stresses the zip tree with a long randomized mix of
+// inserts and deletes and verifies, against an independent leaf-walk
+// (MinKey/MaxKey), that every live node's cached subtree min/max keys
+// (subMin/subMax) stay correct. This is the safety net for the augmented-tree
+// maintenance that the O(1) bbox prune relies on.
+func TestAggregateConsistency(t *testing.T) {
+	tr := newZipTree(rand.New(rand.NewSource(7)))
+	rng := rand.New(rand.NewSource(42))
+	present := map[MortonCode]bool{}
+
+	var verify func(h Handle)
+	verify = func(h Handle) {
+		if h == nilHandle {
+			return
+		}
+		n := tr.nodes[h]
+		wantMin := tr.MinKey(n) // independent O(height) leaf walk
+		wantMax := tr.MaxKey(n)
+		if n.subMin != wantMin || n.subMax != wantMax {
+			t.Fatalf("node key=%d: subMin=%d (want %d) subMax=%d (want %d)",
+				n.Key(), n.subMin, wantMin, n.subMax, wantMax)
+		}
+		verify(n.left)
+		verify(n.right)
+	}
+
+	for i := 0; i < 8000; i++ {
+		k := MortonCode(rng.Intn(1 << 24))
+		if present[k] {
+			tr.Delete(k)
+			delete(present, k)
+		} else {
+			tr.Insert(k)
+			present[k] = true
+		}
+		if i%37 == 0 {
+			verify(tr.root)
+		}
+	}
+	verify(tr.root)
+}

--- a/ziptree.go
+++ b/ziptree.go
@@ -13,9 +13,10 @@ type Handle uint32
 const nilHandle = Handle(0)
 
 type zipNode struct {
-	rankAndKey  uint32 // 8-bit rank, then 24-bit morton code
-	left, right Handle // handles to the left and right children in the pool
-	color       Color  // the key's decoded (x,y,z), cached so the search loop need not re-decode it on every visit
+	rankAndKey     uint32     // 8-bit rank, then 24-bit morton code
+	left, right    Handle     // handles to the left and right children in the pool
+	color          Color      // the key's decoded (x,y,z), cached so the search loop need not re-decode it on every visit
+	subMin, subMax MortonCode // smallest/largest key in this node's subtree, for O(1) bbox pruning
 }
 
 type zipTree struct {
@@ -93,6 +94,10 @@ func (t *zipTree) InsertRec(hroot, hx Handle) Handle {
 			} else {
 				root.left = x.right
 				x.right = hroot
+				// hroot and hx changed children; fix their aggregates
+				// bottom-up (hroot, whose subtree is now final, then hx).
+				t.refresh(hroot)
+				t.refresh(hx)
 				return hx
 			}
 		}
@@ -103,10 +108,14 @@ func (t *zipTree) InsertRec(hroot, hx Handle) Handle {
 			} else {
 				root.right = x.left
 				x.left = hroot
+				t.refresh(hroot)
+				t.refresh(hx)
 				return hx
 			}
 		}
 	}
+	// A descendant of hroot may have changed; recompute its aggregate.
+	t.refresh(hroot)
 	return hroot
 }
 
@@ -134,6 +143,8 @@ func (t *zipTree) DeleteRec(hroot Handle, key MortonCode) Handle {
 			t.DeleteRec(root.right, key)
 		}
 	}
+	// A node was removed somewhere below hroot; recompute its aggregate.
+	t.refresh(hroot)
 	return hroot
 }
 
@@ -147,9 +158,11 @@ func (t *zipTree) zip(hx, hy Handle) Handle {
 	x, y := t.Node(hx), t.Node(hy)
 	if x.Rank() < y.Rank() {
 		t.SetLeft(hy, t.zip(hx, y.left))
+		t.refresh(hy)
 		return hy
 	} else {
 		t.SetRight(hx, t.zip(x.right, hy))
+		t.refresh(hx)
 		return hx
 	}
 }
@@ -181,8 +194,10 @@ func (t *zipTree) Put(handle Handle) {
 func (t *zipTree) Get(rankAndKey uint32) Handle {
 	// Decode the key's color once here, at insert time, instead of on every
 	// search visit. The key is the low 24 bits of rankAndKey.
-	color := mortonCodeToColor(MortonCode(rankAndKey & 0x00FFFFFF))
-	node := zipNode{rankAndKey: rankAndKey, left: nilHandle, right: nilHandle, color: color}
+	key := MortonCode(rankAndKey & 0x00FFFFFF)
+	color := mortonCodeToColor(key)
+	// A fresh node is a leaf, so its subtree min and max are both its own key.
+	node := zipNode{rankAndKey: rankAndKey, left: nilHandle, right: nilHandle, color: color, subMin: key, subMax: key}
 	n := len(t.free)
 	if n > 0 {
 		handle := t.free[n-1]
@@ -193,6 +208,24 @@ func (t *zipTree) Get(rankAndKey uint32) Handle {
 	handle := Handle(len(t.nodes))
 	t.nodes = append(t.nodes, node)
 	return handle
+}
+
+// refresh recomputes a node's cached subtree min/max keys from its children's
+// already-correct aggregates. By the BST ordering the subtree minimum is the
+// left child's subMin (or the node's own key when it has no left child), and
+// symmetrically for the maximum. Callers must refresh bottom-up: a node only
+// after both its children are up to date.
+func (t *zipTree) refresh(h Handle) {
+	n := &t.nodes[h]
+	key := MortonCode(n.rankAndKey & 0x00FFFFFF)
+	n.subMin = key
+	if n.left != nilHandle {
+		n.subMin = t.nodes[n.left].subMin
+	}
+	n.subMax = key
+	if n.right != nilHandle {
+		n.subMax = t.nodes[n.right].subMax
+	}
 }
 
 // Nearest-neighbor search in a 3D color space using an approach described in
@@ -235,7 +268,11 @@ func (t *zipTree) Nearest(q Color, qCode MortonCode) MortonCode {
 		// a.left is only equal to a.right if both are nilHandle
 		// We exclude searching intervals if the distance from the query point to the snug power-of-2 bounding box
 		// enclosing the interval is farther away than our best distance so far.
-		if a.left == a.right || midCode == qCode || distSqToBBox(qCode, t.MinKey(a), t.MaxKey(a), q) >= rSq {
+		// a.subMin/a.subMax are the cached subtree key range, replacing the
+		// former t.MinKey(a)/t.MaxKey(a) leaf-walks (each O(height)) with O(1)
+		// field reads. (MinKey/MaxKey are retained as the brute-force reference
+		// for TestAggregateConsistency.)
+		if a.left == a.right || midCode == qCode || distSqToBBox(qCode, a.subMin, a.subMax, q) >= rSq {
 			return
 		}
 		// If we can't exclude the interval, go ahead with a recursive search.


### PR DESCRIPTION
## Win #2 of 3: cache subtree key range for O(1) bbox pruning

**Stacked on #1** (cache node color). Review/merge #1 first. Pure performance change — **output is byte-for-byte unchanged**. This is the largest of the three wins.

```
#1 cache node color      → merged/under review
#2 cache subtree bbox    → this PR        (base: perf-1-cache-color)
#3 de-closure the search → stacked on #2
```

### What & why
The search prunes a subtree when the query's distance to the bounding box of that subtree's keys exceeds the best distance so far — which needs the subtree's **min and max key**. Previously each prune called `MinKey(a)`/`MaxKey(a)`, and *each* of those walks pointer-by-pointer down to a leaf: **O(height) per prune**, chasing ~15–20 dependent, cache-missing indexes into the node pool per query. The instrumentation showed ~140–175 leaf-walk steps per query versus only ~20 actual search-node visits — the walks dominated.

This PR augments each node with `subMin`/`subMax` (the min/max key over its subtree) and maintains them incrementally: `refresh()` recomputes a node from its children's aggregates in O(1), called bottom-up on every structural change in `InsertRec`, `DeleteRec`, and `zip`. The prune then reads `a.subMin`/`a.subMax` directly.

### Measured
~**1.9×** stacked (the marginal effect of removing only the walk, isolated via the A/B harness, is ~1.86×). This is where the bulk of the speedup comes from.

### Correctness
- `TestGoldenOutput`: output identical to baseline.
- `TestAggregateConsistency` (new): fuzzes 8000 randomized insert/deletes and checks every live node's cached `subMin`/`subMax` against an independent `MinKey`/`MaxKey` leaf-walk. `MinKey`/`MaxKey` are retained precisely as this test's reference.

### Contents
- `ziptree.go`: `subMin`/`subMax` fields + `refresh()`; maintenance calls in `InsertRec`/`DeleteRec`/`zip`; prune reads the cached range.
- `aggregate_test.go`: the invariant fuzz test.
