### PR TITLE
perf: remove dead scratch fields from zipTree (revert no-op #3)

### DIFF
--- a/ziptree.go
+++ b/ziptree.go
@@ -24,17 +24,6 @@ type zipTree struct {
 	nodes []zipNode // pool of pre-allocated nodes
 	free  []Handle  // free list
 	rng   *rand.Rand
-
-	// Per-query scratch for the nearest-neighbor search. Kept on the tree (not
-	// captured by a closure) so the recursive search is a plain method with no
-	// per-query heap allocation or closure-call overhead. Safe because each
-	// tree is owned by a single goroutine — its Canvas — and parallel runs use
-	// independent canvases/trees.
-	q                  Color
-	qCode              MortonCode
-	rSq                uint32
-	best               MortonCode
-	qPosCode, qNegCode MortonCode
 }
 
 func newZipTree(rng *rand.Rand) *zipTree {


### PR DESCRIPTION
## Remove dead scratch fields from `zipTree` (revert the no-op part of #3)

PR #3 ("de-closure the search") **shipped broken.** It added per-query scratch fields to `zipTree` but the closure→method conversion never actually applied — a silently-failed edit. The fields were added but never read. Build, `go vet`, and `TestGoldenOutput` all passed precisely *because* unused struct fields are legal Go and the output was unchanged, so nothing caught it. (Thanks to the reviewer who noticed "it just added fields I didn't see used" — exactly right.)

### Why remove rather than complete it
A careful interleaved A/B on the **real** `Nearest` (not the throwaway `FastN` variants the original "~2.1×" claim was based on — that comparison was confounded) shows the de-closure is worth only **~1%**, and it makes the tree non-reentrant (shared mutable search state). Not worth the subtlety, so this removes the dead fields and keeps the clean closure form.

### Effect
- No performance change vs current main — #3 was already a no-op, so `main` was running on wins #1+#2 the whole time.
- `main` keeps **win #1** (cached node color) and **win #2** (O(1) subtree-bbox prune): ~1.9× over the pre-optimization baseline.
- Output unchanged (`TestGoldenOutput`); subtree-aggregate invariant still fuzz-checked (`TestAggregateConsistency`).

### Diff
Removes 6 unused fields + their comment from the `zipTree` struct. Nothing else.
